### PR TITLE
suppress some clang compiler warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,9 @@ fips_begin_lib(pbc)
         src/wmessage.c
     )
 fips_end_lib()
+if (FIPS_CLANG)
+    set_target_properties(pbc PROPERTIES COMPILE_FLAGS "-Wno-sign-compare")
+endif()
 
 if (NOT FIPS_IMPORT)
     fips_finish()


### PR DESCRIPTION
This pull requests suppresses a signed/unsigned comparison warning when compiling PBC with clang.